### PR TITLE
Add in dependency management to created aggregator pom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ oclif.manifest.json
 yarn.lock
 pnpm-lock.yaml
 
-
+tsconfig.tsbuildinfo
 **/.claude/settings.local.json

--- a/src/maven-gav.ts
+++ b/src/maven-gav.ts
@@ -1,0 +1,21 @@
+export default class MavenGAVCoords {
+    private readonly groupId: string;
+    private readonly artifactId: string;
+    private readonly version: string;
+
+    constructor(groupId: string, artifactId: string, version: string) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
+
+    getGroupId(): string {
+        return this.groupId;
+    }
+    getArtifactId(): string {
+        return this.artifactId;
+    }
+    getVersion(): string {
+        return this.version;
+    }
+}


### PR DESCRIPTION
This PR pulls in the non parent POM GAVs into the dependency management section is what gets generated if I move the one maven module in the `final-repos` dir created after running `just workflow-test false`
```
<?xml version="1.0"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.example</groupId>
  <artifactId>maven-aggregator</artifactId>
  <version>1.0.0-SNAPSHOT</version>
  <packaging>pom</packaging>
  <name>maven-aggregator Aggregator POM</name>
  <description>Aggregator POM for multiple Maven repositories</description>
  <modules>
    <module>motlin/JUnit-Java-8-Runner</module>
  </modules>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>com.motlin</groupId>
        <artifactId>junit-java8-runner-tests</artifactId>
        <version>0.1.0-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>com.motlin</groupId>
        <artifactId>junit-java8-runner</artifactId>
        <version>0.1.0-SNAPSHOT</version>
      </dependency>
    </dependencies>
  </dependencyManagement>
</project>
```
Here is a screenshot of what running the command looks like: 
<img width="943" alt="image" src="https://github.com/user-attachments/assets/83bc977a-7355-454d-86a5-82845e333789" />
