### PR TITLE
Update regex to be more flexible to other GH instances

### DIFF
--- a/src/commands/repo/list.ts
+++ b/src/commands/repo/list.ts
@@ -52,7 +52,7 @@ export default class RepoList extends Command {
       // Build the GitHub API search query
       const topicQueries = topics.map((topic) => `topic:${topic}`).join(' ')
       const languageQueries = languages.map((language) => `language:${language}`).join(' ')
-      const query = `user:${username} ${topicQueries} ${languageQueries}`.trim()
+      const query = `user:${username} ${topicQueries} ${languageQueries} archived:false`.trim()
       this.log(`│  │  │ Query: ${query}`)
       this.log(`│  ├──╯`)
 

--- a/src/commands/repo/tag.ts
+++ b/src/commands/repo/tag.ts
@@ -235,8 +235,8 @@ export default class RepoTag extends Command {
       const {stdout} = await execa('git', ['-C', repoPath, 'remote', 'get-url', 'origin'])
 
       // Handle SSH and HTTPS remote URLs
-      const sshMatch = stdout.match(/git@github\.com:([^/]+)\/([^/]+)(\.git)?$/)
-      const httpsMatch = stdout.match(/https:\/\/github\.com\/([^/]+)\/([^/]+)(\.git)?$/)
+      const sshMatch = stdout.match(/git@github\.[^\/]+\.com:([^/]+)\/([^/]+)(\.git)?$/)
+      const httpsMatch = stdout.match(/https:\/\/github\.[^\/]+\.com\/([^/]+)\/([^/]+)(\.git)?$/)
 
       const match = sshMatch || httpsMatch
 


### PR DESCRIPTION
Currently, this will fail to mark Maven codebases as valid if we aren't working with public GH. This makes the regex a little more flexible