### PR TITLE
Upgrade just to 1.52.0

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,6 +1,6 @@
 [tools]
 java = "temurin-21.0.6+7.0.LTS"
-just = "1.45.0"
+just = "1.52.0"
 node = "24.11.1"
 npm = "11.4.2"
 maven = "3.9.11"


### PR DESCRIPTION
Bumps the pinned `just` version to 1.52.0 in `.mise/config.toml` to match the project-template baseline.